### PR TITLE
Fix hover in GitHub Codespaces

### DIFF
--- a/ghul.json
+++ b/ghul.json
@@ -1,4 +1,5 @@
 {
+    "want_plaintext_hover": true,
     "source": [
         "src"
     ]


### PR DESCRIPTION
The Codespaces version of Visual Studio Code does not support the deprecated `MarkedString` type for hover request responses. Set the `want_plaintext_hover` flag in `ghul.json` to use plain text instead.